### PR TITLE
Fixed bug using {$eq: ...} queries and improved error handling

### DIFF
--- a/lib/plugins/mongoose-encryption.js
+++ b/lib/plugins/mongoose-encryption.js
@@ -155,30 +155,37 @@ var mongooseEncryption = function(schema, options) {
     } catch (err) {
       throw new Error("Could not retrieve " + idForKey + " from the query.");
     }
-    
+
     var key = keyStore[id];
     //delete keyStore[id];
 
     if (typeof key === "undefined") {
-      throw new Error("Could not retrieve keyEncrypt for userId " + id + " from keyStore.");
+      throw new Error(
+        "Could not retrieve keyEncrypt for userId " + id + " from keyStore."
+      );
     }
     // call function associated with model instance. TODO save in here instead?
     return key;
   };
 
   const setKeyFromQuery = query => {
-    try {
-      var id = query._conditions[idForKey];
-      var encryptionKey = query._conditions["keyEncrypt"].toString();
-    } catch (err) {
+    var id = query._conditions[idForKey];
+    if (!id)
       throw new Error(
-        " Could not extract keyEncrypt from query. Did you include " +
+        "Error extracting keyEncrypt from query. Pass " +
           idForKey +
-          " and keyEncrypt?"
+          " in query."
       );
-    }
+    if (typeof id === "object" && id.$eq) id = id.$eq;
+    id = id.toString();
+
+    var key = query._conditions["keyEncrypt"];
+    if (!key) throw new Error("Error extracting keyEncrypt from query. Pass keyEncrypt in query.");
+    if (typeof key === "object" && key.$eq) key = key.$eq;
+    key = key.toString();
+
     query.where("keyEncrypt").equals(null);
-    keyStore[id] = encryptionKey;
+    keyStore[id] = key;
   };
 
   const setKeyFromDocument = doc => {
@@ -186,7 +193,9 @@ var mongooseEncryption = function(schema, options) {
     let id = doc[idForKey];
     if (typeof encryptionKey === "undefined" || typeof id === "undefined") {
       throw new Error(
-        "Did not find required keyEncrypt or " + idForKey + "in Mongoose document. "
+        "Did not find required keyEncrypt or " +
+          idForKey +
+          "in Mongoose document. "
       );
     }
     doc._myKey = null;
@@ -226,9 +235,8 @@ var mongooseEncryption = function(schema, options) {
         throw new Error("_ac cannot be in array of fields to authenticate");
       }
 
-      var collectionId = options.collectionId ||
-        modelName ||
-        doc.constructor.modelName;
+      var collectionId =
+        options.collectionId || modelName || doc.constructor.modelName;
 
       if (!collectionId) {
         throw new Error(
@@ -303,11 +311,16 @@ var mongooseEncryption = function(schema, options) {
     // defaults to true
 
     schema.pre("init", function(next, data) {
-      var encryptionKey = getKeyForQueryResponse(data);
-      //console.log("init, using key: " + encryptionKey);
-      encryptionKey = keyIntoBuffer(encryptionKey);
-
       var err = null;
+
+      try {
+        var encryptionKey = getKeyForQueryResponse(data);
+        //console.log("init, using key: " + encryptionKey);
+        encryptionKey = keyIntoBuffer(encryptionKey);
+      } catch (err) {
+        return next(err);
+      }
+
       try {
         // this hook must be synchronous for embedded docs, so everything is synchronous for code simplicity
         if (options.authenticate && !isEmbeddedDocument(this)) {
@@ -345,11 +358,14 @@ var mongooseEncryption = function(schema, options) {
 
     schema.pre("save", function(next) {
       var that = this;
+      let encryptionKey;
 
-      // get Keys
-      let encryptionKey = setKeyFromDocument(that);
-      //console.log("save, using key : " + encryptionKey);
-      encryptionKey = keyIntoBuffer(encryptionKey);
+      try {
+        encryptionKey = setKeyFromDocument(that);
+        encryptionKey = keyIntoBuffer(encryptionKey);
+      } catch (err) {
+        return next(err);
+      }
 
       if (!options.authenticate) {
         if (this.isNew || this.isSelected("_ct")) {
@@ -383,7 +399,8 @@ var mongooseEncryption = function(schema, options) {
             }
           });
         } else if (
-          allAuthenticationFieldsSelected(this) && !isEmbeddedDocument(this)
+          allAuthenticationFieldsSelected(this) &&
+          !isEmbeddedDocument(this)
         ) {
           // _ct is not selected but all authenticated fields are. cannot get hit in current version.
           _.forEach(authenticatedFields, function(authenticatedField) {
@@ -402,7 +419,7 @@ var mongooseEncryption = function(schema, options) {
       schema.post("save", function(doc) {
         if (_.isFunction(doc.decryptSync)) {
           let encryptionKey = getKeyForQueryResponse(doc);
-          encryptionKey =  keyIntoBuffer(encryptionKey);
+          encryptionKey = keyIntoBuffer(encryptionKey);
           doc.decryptSync(encryptionKey);
         }
 
@@ -418,15 +435,23 @@ var mongooseEncryption = function(schema, options) {
 
     /* Define hooks on the  query level */
 
-    schema.pre("findOne", function(next) {
-      setKeyFromQuery(this);
+    const findMiddleware = function(next, me) {
+      console.log("CALLING FIND MIDDLEWARE");
+      try {
+        setKeyFromQuery(me);
+      } catch (err) {
+        console.log("FIND MIDDLEWARE ERROR " + err);
+        next(err);
+      }
       next();
+    };
+
+    schema.pre("findOne", function(next) {
+      return findMiddleware(next, this);
     });
 
-
     schema.pre("find", function(next) {
-      setKeyFromQuery(this);
-      next();
+      return findMiddleware(next, this);
     });
   }
 
@@ -436,9 +461,9 @@ var mongooseEncryption = function(schema, options) {
     var that = this;
 
     if (this._ct) {
-      return cb(new Error(
-        "Encrypt failed: document already contains ciphertext"
-      ));
+      return cb(
+        new Error("Encrypt failed: document already contains ciphertext")
+      );
     }
 
     // generate random iv
@@ -501,8 +526,8 @@ var mongooseEncryption = function(schema, options) {
         iv
       );
       try {
-        decryptedObjectJSON = decipher.update(ct, undefined, "utf8") +
-          decipher.final("utf8");
+        decryptedObjectJSON =
+          decipher.update(ct, undefined, "utf8") + decipher.final("utf8");
         decryptedObject = JSON.parse(decryptedObjectJSON);
       } catch (err) {
         if (this._id) {

--- a/lib/plugins/mongoose-encryption.js
+++ b/lib/plugins/mongoose-encryption.js
@@ -436,11 +436,9 @@ var mongooseEncryption = function(schema, options) {
     /* Define hooks on the  query level */
 
     const findMiddleware = function(next, me) {
-      console.log("CALLING FIND MIDDLEWARE");
       try {
         setKeyFromQuery(me);
       } catch (err) {
-        console.log("FIND MIDDLEWARE ERROR " + err);
         next(err);
       }
       next();

--- a/test/encryptOnly.test.js
+++ b/test/encryptOnly.test.js
@@ -4,7 +4,6 @@ var mongoose = require("mongoose");
 var Mockgoose = require("mockgoose").Mockgoose;
 var mockgoose = new Mockgoose(mongoose);
 var crypto = require("crypto");
-mongoose.set("debug", true);
 
 var config = {
   db: process.env.MONGODB_URI || "mongodb://localhost/tpfdb"
@@ -76,11 +75,34 @@ test("create document, find it.", async done => {
   done();
 });
 
+test("create document, find it using $eq.", async done => {
+  try {
+    let compareKeys = Object.keys(testAccount);
+    testAccount.keyEncrypt = crypto.randomBytes(32).toString("base64");
+
+    let res = await Account.create(testAccount);
+
+    let query = Account.findOne({
+      userId: { $eq: testAccount.userId },
+      keyEncrypt: { $eq: testAccount.keyEncrypt }
+    });
+
+    res = await query;
+    expect(filterObject(res, compareKeys)).toEqual(
+      filterObject(testAccount, compareKeys)
+    );
+  } catch (err) {
+    console.log("Error " + err);
+    expect(true).toBe(false);
+  }
+  done();
+});
+
 test.skip("create array of docs", async done => {
-  // This test fails if getKeyForQueryResponse deletes the key from keyStore. 
+  // This test fails if getKeyForQueryResponse deletes the key from keyStore.
   // It's probably due to the asyncronous nature of the save calls created by .create
   // One way out would be to identify the key not only by userId, but also by e.g. a hash of the doc to save
-  // 
+  //
   try {
     let compareKeys = Object.keys(testAccount);
     testAccount.keyEncrypt = crypto.randomBytes(32).toString("base64");


### PR DESCRIPTION
@anselms As discussed.

There was a bug where queries for keyEncrypt and the keyStore id in the form { $eq: value } were not handled correctly.

This fixes it for both keyEncrypt as well as the keyStore id.